### PR TITLE
issueID #3 Uncaught ReferenceError: options is not defined

### DIFF
--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -251,7 +251,7 @@ $(document).on( 'init.dt', function ( e, settings ) {
 	if ( settings.oInit.rowsGroup ||
 		 $.fn.dataTable.defaults.rowsGroup )
 	{
-		options = settings.oInit.rowsGroup?
+		var options = settings.oInit.rowsGroup?
 			settings.oInit.rowsGroup:
 			$.fn.dataTable.defaults.rowsGroup;
 		var rowsGroup = new RowsGroup( api, options );


### PR DESCRIPTION
		var options = settings.oInit.rowsGroup?
			settings.oInit.rowsGroup:
			$.fn.dataTable.defaults.rowsGroup;