### PR TITLE
issueID #4 Uncaught ReferenceError: currentColumn is not defined

### DIFF
--- a/dataTables.rowsGroup.js
+++ b/dataTables.rowsGroup.js
@@ -190,7 +190,7 @@ RowsGroup.prototype = {
 	_mergeColumn: function(iStartRow, iFinishRow, columnsIndexes)
 	{
 		var columnsIndexesCopy = columnsIndexes.slice()
-		currentColumn = columnsIndexesCopy.shift()
+		var currentColumn = columnsIndexesCopy.shift()
 		currentColumn = this.table.column(currentColumn, ShowedDataSelectorModifier)
 		
 		var columnNodes = currentColumn.nodes()


### PR DESCRIPTION
		var currentColumn = columnsIndexesCopy.shift()